### PR TITLE
Add quotes to paths used in `run`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: perl6
 
 perl6:
+  - 2018.02
   - 2018.01
 
 os:

--- a/lib/App/Assixt/Commands/Bootstrap/Man.pm6
+++ b/lib/App/Assixt/Commands/Bootstrap/Man.pm6
@@ -39,10 +39,10 @@ multi sub MAIN(
 
 	chdir $source.IO.parent.path;
 
-	run « a2x -f manpage {$verbose ?? "-v" !! ""} {$source.IO.path} »;
+	run « a2x -f manpage {$verbose ?? "-v" !! ""} "{$source.IO.path}" »;
 	say $source.IO.path;
 	say $page;
-	run « gzip $page »;
+	run « gzip "$page" »;
 	mkdir $destination.IO.parent.path;
 
 	if (!move "$page.gz", $destination) {

--- a/lib/App/Assixt/Commands/Depend.pm6
+++ b/lib/App/Assixt/Commands/Depend.pm6
@@ -20,7 +20,7 @@ multi sub MAIN("depend", Str $module, Bool :$no-install = False) is export
 
 	# Install the new dependency with zef
 	if (!$no-install) {
-		my $zef = run « zef --cpan install $module »;
+		my $zef = run « zef --cpan install "$module" »;
 
 		die "Zef failed, bailing" if 0 < $zef.exitcode;
 	}

--- a/lib/App/Assixt/Commands/Dist.pm6
+++ b/lib/App/Assixt/Commands/Dist.pm6
@@ -51,15 +51,15 @@ multi sub MAIN(
 	}
 
 	if ($verbose) {
-		say "tar czf $output {@tar-flags} .";
+		say "tar czf \"$output\" {@tar-flags} .";
 	}
 
-	run « tar czf $output {@tar-flags} .», :err;
+	run « tar czf "$output" {@tar-flags} .», :err;
 
 	say "Created {$output}";
 
 	if ($verbose) {
-		my $list = run « tar tf $output », :out;
+		my $list = run « tar tf "$output" », :out;
 
 		for $list.out.lines -> $line {
 			say "  {$line}";

--- a/lib/App/Assixt/Commands/Dist.pm6
+++ b/lib/App/Assixt/Commands/Dist.pm6
@@ -51,7 +51,7 @@ multi sub MAIN(
 	}
 
 	if ($verbose) {
-		say "tar czf \"$output\" {@tar-flags} .";
+		say "tar czf {$output.perl} {@tar-flags} .";
 	}
 
 	run « tar czf "$output" {@tar-flags} .», :err;

--- a/lib/App/Assixt/Commands/Upload.pm6
+++ b/lib/App/Assixt/Commands/Upload.pm6
@@ -45,7 +45,7 @@ multi sub MAIN("upload", Str $dist, Str :$pause-id = "", Str :$pause-password = 
 
 	die "'tar' is not available on this system" unless which("tar");
 
-	run « tar xzf $dist -C $tempdir »;
+	run « tar xzf "$dist" -C "$tempdir" »;
 
 	my %meta = get-meta($tempdir.IO.add($dist.IO.extension("", :parts(2)).basename).absolute);
 	my $distname = "{%meta<name>.subst("::", "-", :g)}-{%meta<version>}";

--- a/t/command-dist.t
+++ b/t/command-dist.t
@@ -56,6 +56,19 @@ subtest ":output-dir overrides config-set output-dir", {
 	ok "$output-dir/Local-Test-Dist-0.0.0.tar.gz".IO.e, "Tarball exists";
 };
 
+subtest ":output-dir set to a path with spaces", {
+	plan 2;
+
+	my Str $output-dir = "$root/output beta";
+
+	ok MAIN(
+		"dist",
+		:$output-dir,
+	), "assixt dist";
+
+	ok "$output-dir/Local-Test-Dist-0.0.0.tar.gz".IO.e, "Tarball exists";
+}
+
 subtest "Dist in other path can be created", {
 	plan 2;
 

--- a/t/command-dist.t
+++ b/t/command-dist.t
@@ -9,7 +9,7 @@ use File::Temp;
 use File::Which;
 use Test;
 
-plan 4;
+plan 5;
 
 skip-rest "'tar' is not available" and exit unless which("tar");
 
@@ -59,7 +59,7 @@ subtest ":output-dir overrides config-set output-dir", {
 subtest ":output-dir set to a path with spaces", {
 	plan 2;
 
-	my Str $output-dir = "$root/output beta";
+	my Str $output-dir = "$root/output gamma";
 
 	ok MAIN(
 		"dist",


### PR DESCRIPTION
Variables in << >> contstructs are split on whitespace, which is different from
what I gathered from earlier discussion. This in turn led to paths with spaces
breaking normal usage. This patch applies quotes to such arguments, in order to
make App::Assixt behave as expected.

Closes #1