### PR TITLE
Fixes downstream version error

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
   "depends": [
     "Config::Parser::toml:ver<1.0.1>",
     "Config:ver<1.3.2>",
-    "Dist::Helper:ver<0.19.1>",
+    "Dist::Helper:ver<0.19.2>",
     "Terminal::Getpass"
   ],
   "description": "A CLI frontend to Dist::Helper",

--- a/t/command-bump.t
+++ b/t/command-bump.t
@@ -8,47 +8,48 @@ use Dist::Helper::Meta;
 use File::Temp;
 use Test;
 
-plan 4;
-
 multi sub MAIN { 0 }
 
 my $root = tempdir;
 
 chdir $root;
 
-ok MAIN(
-	"new",
-	name => "Local::Test::Bump",
-	author => "Patrick Spek",
-	email => "p.spek@tyil.work",
-	perl => "c",
-	description => "Nondescript",
-	license => "GPL-3.0",
-	no-user-config => True,
-), "assixt new Local::Test::Bump";
+plan 4;
 
-subtest "Bump patch version", {
-	plan 3;
 
-	is get-meta()<version>, "0.0.0", "Version is now at 0.0.0";
-	ok MAIN("bump", "patch", :force), "Bump patch level";
-	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
-};
+# ok MAIN(
+# 	"new",
+# 	name => "Local::Test::Bump",
+# 	author => "Patrick Spek",
+# 	email => "p.spek@tyil.work",
+# 	perl => "c",
+# 	description => "Nondescript",
+# 	license => "GPL-3.0",
+# 	no-user-config => True,
+# ), "assixt new Local::Test::Bump";
 
-subtest "Bump minor version", {
-	plan 3;
+# subtest "Bump patch version", {
+# 	plan 3;
 
-	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
-	ok MAIN("bump", "minor", :force), "Bump minor level";
-	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
-};
+# 	is get-meta()<version>, "0.0.0", "Version is now at 0.0.0";
+# 	ok MAIN("bump", "patch", :force), "Bump patch level";
+# 	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
+# };
 
-subtest "Bump major version", {
-	plan 3;
+# subtest "Bump minor version", {
+# 	plan 3;
 
-	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
-	ok MAIN("bump", "major", :force), "Bump major level";
-	is get-meta()<version>, "1.0.0", "Version is now at 1.0.0";
-};
+# 	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
+# 	ok MAIN("bump", "minor", :force), "Bump minor level";
+# 	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
+# };
+
+# subtest "Bump major version", {
+# 	plan 3;
+
+# 	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
+# 	ok MAIN("bump", "major", :force), "Bump major level";
+# 	is get-meta()<version>, "1.0.0", "Version is now at 1.0.0";
+# };
 
 # vim: ft=perl6 noet

--- a/t/command-bump.t
+++ b/t/command-bump.t
@@ -8,48 +8,47 @@ use Dist::Helper::Meta;
 use File::Temp;
 use Test;
 
+plan 4;
+
 multi sub MAIN { 0 }
 
 my $root = tempdir;
 
 chdir $root;
 
-plan 4;
+ok MAIN(
+	"new",
+	name => "Local::Test::Bump",
+	author => "Patrick Spek",
+	email => "p.spek@tyil.work",
+	perl => "c",
+	description => "Nondescript",
+	license => "GPL-3.0",
+	no-user-config => True,
+), "assixt new Local::Test::Bump";
 
+subtest "Bump patch version", {
+	plan 3;
 
-# ok MAIN(
-# 	"new",
-# 	name => "Local::Test::Bump",
-# 	author => "Patrick Spek",
-# 	email => "p.spek@tyil.work",
-# 	perl => "c",
-# 	description => "Nondescript",
-# 	license => "GPL-3.0",
-# 	no-user-config => True,
-# ), "assixt new Local::Test::Bump";
+	is get-meta()<version>, "0.0.0", "Version is now at 0.0.0";
+	ok MAIN("bump", "patch", :force), "Bump patch level";
+	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
+};
 
-# subtest "Bump patch version", {
-# 	plan 3;
+subtest "Bump minor version", {
+	plan 3;
 
-# 	is get-meta()<version>, "0.0.0", "Version is now at 0.0.0";
-# 	ok MAIN("bump", "patch", :force), "Bump patch level";
-# 	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
-# };
+	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
+	ok MAIN("bump", "minor", :force), "Bump minor level";
+	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
+};
 
-# subtest "Bump minor version", {
-# 	plan 3;
+subtest "Bump major version", {
+	plan 3;
 
-# 	is get-meta()<version>, "0.0.1", "Version is now at 0.0.1";
-# 	ok MAIN("bump", "minor", :force), "Bump minor level";
-# 	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
-# };
-
-# subtest "Bump major version", {
-# 	plan 3;
-
-# 	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
-# 	ok MAIN("bump", "major", :force), "Bump major level";
-# 	is get-meta()<version>, "1.0.0", "Version is now at 1.0.0";
-# };
+	is get-meta()<version>, "0.1.0", "Version is now at 0.1.0";
+	ok MAIN("bump", "major", :force), "Bump major level";
+	is get-meta()<version>, "1.0.0", "Version is now at 1.0.0";
+};
 
 # vim: ft=perl6 noet


### PR DESCRIPTION
Although it still continues with the old error:

```
$ zef test .
===> Testing: App::Assixt:ver<0.1.4>
Usage:
  t/command-bump.t [--output-dir=<Str>] [--force] [--verbose] dist <path> 
  t/command-bump.t [--output-dir=<Str>] [--force] [--verbose] dist 
  t/command-bump.t [--output-dir=<Str>] [--force] [--verbose] dist <paths>
```
