### PR TITLE
Run prove in sink context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - `api` flag added to META6.json
 
 ### Changed
-- `author` field now defaults to being an array
+- `author` field now defaults to being an array.
+- `assixt test` now calls `run` in sink context, to avoid output of a Failure
+  when `prove` found failing tests. [GitHub#7](https://github.com/scriptkitties/perl6-app-assixt/issues/7)
 
 ## [0.2.4] - 2018-03-29
 ### Changed

--- a/lib/App/Assixt/Commands/Test.pm6
+++ b/lib/App/Assixt/Commands/Test.pm6
@@ -9,6 +9,6 @@ class App::Assixt::Commands::Test
 	method run(
 		Config:D :$config,
 	) {
-		run « prove -e "perl6 -Ilib" »
+		run(« prove -e "perl6 -Ilib" »).so
 	}
 }


### PR DESCRIPTION
Closes #7. The sink context should stop the Failure from the non-zero
`prove` command from producing messy output. Non-zero returns from
`prove` are expected behaviour, and should not needlessly produce a
messy output when ran via `assixt`.